### PR TITLE
update to namespace import

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
-import fs from "fs";
+import * as fs from "fs";
 import { IncomingMessage } from "http";
-import http from "https";
+import * as http from "https";
 
 const scarfApiToken = process.env.SCARF_API_TOKEN;
 if (!scarfApiToken) throw "missing env variable: SCARF_API_TOKEN";


### PR DESCRIPTION
This change is fixes the error I encountered when trying to run the project
```
index.ts:2:8 - error TS1192: Module '"fs"' has no default export.

2 import fs from "fs";
         ~~

index.ts:4:8 - error TS1192: Module '"https"' has no default export.

4 import http from "https";
         ~~~~


Found 2 errors in the same file, starting at: index.ts:2
```